### PR TITLE
Move preact to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "deep-equal": "^1.0.1",
     "object-assign": "^4.0.1",
-    "preact-side-effect": "^1.2.0"
+    "preact-side-effect": "^1.3.0"
   },
   "peerDependencies": {
     "preact": ">=7.1.0"

--- a/package.json
+++ b/package.json
@@ -30,8 +30,10 @@
   "dependencies": {
     "deep-equal": "^1.0.1",
     "object-assign": "^4.0.1",
-    "preact": "^7.1.0",
     "preact-side-effect": "^1.2.0"
+  },
+  "peerDependencies": {
+    "preact": ">=7.1.0"
   },
   "devDependencies": {
     "babel-cli": "6.22.2",
@@ -68,7 +70,8 @@
     "karma-webpack": "2.0.2",
     "mocha": "3.2.0",
     "phantomjs-prebuilt": "2.1.14",
-    "preact-render-to-string": "^3.5.0",
+    "preact": "7.1.0",
+    "preact-render-to-string": "3.5.0",
     "rimraf": "2.5.4",
     "sinon": "1.17.7",
     "sinon-chai": "2.8.0",


### PR DESCRIPTION
This gives control over the version of preact to the parent project which uses this project.

Otherwise, if the main project is using preact version 8+, then a bundle would contain both the preact 8+ from the main project and the preact 7.1.0 from this project.

Note: Fixing the `preact-render-to-string` to 3.5.0, because 3.6.0 introduced some changes to who self closing tags are rendered and tests began failing.